### PR TITLE
Updating PostgreSQL template for Gen5 and 2017-12-01 apiVersion.

### DIFF
--- a/mlserver-arm-templates/enterprise-configuration/linux-postgresql/azuredeploy.json
+++ b/mlserver-arm-templates/enterprise-configuration/linux-postgresql/azuredeploy.json
@@ -231,21 +231,25 @@
     {
       "type": "Microsoft.DBforPostgreSQL/servers",
       "sku": {
-          "name": "PGSQLB100",
+          "name": "B_Gen5_1",
           "tier": "Basic",
-          "capacity": 100,
+          "capacity": 1,
           "size": 51200,
-          "family": "SkuFamily"
+          "family": "Gen5"
       },
       "kind": "",
       "name": "[variables('postgresqlName')]",
-      "apiVersion": "2016-02-01-privatepreview",
+      "apiVersion": "2017-12-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
           "version": "9.6",
           "administratorLogin": "[parameters('adminUsername')]",
           "administratorLoginPassword": "[parameters('adminPassword')]",
-          "storageMB": 51200
+          "storageProfile": {
+            "storageMB": 51200,
+            "backupRetentionDays": 7,
+            "geoRedundantBackup": "Disabled"
+          }
       },
       "resources":[
         {


### PR DESCRIPTION
Since Gen5 is now the most common hardware level in Azure data centers deployment failed with the old template. I went in and updated this template to make use of Gen-5.