### PR TITLE
apiVersion for firewallrules updated to currenlty supported version

### DIFF
--- a/mlserver-arm-templates/enterprise-configuration/linux-postgresql/azuredeploy.json
+++ b/mlserver-arm-templates/enterprise-configuration/linux-postgresql/azuredeploy.json
@@ -254,7 +254,7 @@
       "resources":[
         {
           "type":"firewallrules",
-          "apiVersion":"2016-02-01-privatepreview",
+          "apiVersion":"2017-12-01",
           "dependsOn":[
             "[concat('Microsoft.DBforPostgreSQL/servers/', variables('postgresqlName'))]"
           ],


### PR DESCRIPTION
apiVersion "2016-02-01-privatepreview" seems to be no longer supported, I had to switch to the "2017-12-01" to use the template.